### PR TITLE
Remove ServiceNow-specific columns from Ticket model

### DIFF
--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -68,8 +68,6 @@ class Ticket(Base):
     root_cause: Mapped[str | None] = mapped_column(Text)
     status: Mapped[TicketStatus | None] = mapped_column(Enum(TicketStatus))
     priority: Mapped[str | None] = mapped_column(String(50))
-    assignment_group: Mapped[str | None] = mapped_column(String(255))
-    cmdb_ci: Mapped[str | None] = mapped_column(String(255))
     is_resolved: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())


### PR DESCRIPTION
## Summary
- Removes `assignment_group` and `cmdb_ci` from the `Ticket` SQLAlchemy ORM model
- These columns were never in Pydantic schemas or used in any endpoint
- Corresponding columns dropped from Supabase via `ALTER TABLE tickets DROP COLUMN IF EXISTS`

## Test plan
- [ ] Railway deploys cleanly (startup schema assertions pass)
- [ ] `GET /api/v1/tickets` still returns expected fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)