### PR TITLE
Add power search and column sorting to ticket table

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -16,6 +16,21 @@ import {
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Badge } from "@/components/ui/badge";
+import {
+  ArrowUp,
+  ArrowDown,
+  ArrowUpDown,
+  ListFilter,
+  ChevronLeft,
+  X,
+} from "lucide-react";
 
 const EMPTY_CLIENT_VALUE = "__none__";
 
@@ -28,6 +43,235 @@ type Ticket = {
   is_resolved: boolean;
   created_at: string;
 };
+
+type SortColumn = "external_id" | "short_desc" | "status" | "created_at";
+type SortDirection = "asc" | "desc";
+
+type FilterColumn =
+  | "external_id"
+  | "short_desc"
+  | "status"
+  | "priority"
+  | "is_resolved";
+type FilterOperator = "contains" | "does_not_contain" | "is" | "is_not";
+type Filter = {
+  id: string;
+  column: FilterColumn;
+  operator: FilterOperator;
+  value: string;
+};
+
+const FILTER_COLUMNS: Record<
+  FilterColumn,
+  {
+    label: string;
+    type: "text" | "enum" | "boolean";
+    operators: FilterOperator[];
+    options: string[] | null;
+  }
+> = {
+  external_id: {
+    label: "External ID",
+    type: "text",
+    operators: ["contains", "does_not_contain", "is", "is_not"],
+    options: null,
+  },
+  short_desc: {
+    label: "Summary",
+    type: "text",
+    operators: ["contains", "does_not_contain", "is", "is_not"],
+    options: null,
+  },
+  status: {
+    label: "Status",
+    type: "enum",
+    operators: ["is", "is_not"],
+    options: ["OPEN", "CLOSED"],
+  },
+  priority: {
+    label: "Priority",
+    type: "text",
+    operators: ["contains", "does_not_contain", "is", "is_not"],
+    options: null,
+  },
+  is_resolved: {
+    label: "Resolved",
+    type: "boolean",
+    operators: ["is"],
+    options: ["Yes", "No"],
+  },
+};
+
+const OPERATOR_LABELS: Record<FilterOperator, string> = {
+  contains: "contains",
+  does_not_contain: "does not contain",
+  is: "is",
+  is_not: "is not",
+};
+
+function FilterPopoverContent({
+  onAdd,
+  onClose,
+}: {
+  onAdd: (f: Filter) => void;
+  onClose: () => void;
+}) {
+  const [step, setStep] = useState<1 | 2 | 3>(1);
+  const [selectedColumn, setSelectedColumn] = useState<FilterColumn | null>(
+    null,
+  );
+  const [selectedOperator, setSelectedOperator] =
+    useState<FilterOperator | null>(null);
+  const [value, setValue] = useState("");
+
+  function handleColumnSelect(col: FilterColumn) {
+    setSelectedColumn(col);
+    const config = FILTER_COLUMNS[col];
+    if (config.operators.length === 1) {
+      setSelectedOperator(config.operators[0]);
+      setStep(3);
+    } else {
+      setStep(2);
+    }
+  }
+
+  function handleOperatorSelect(op: FilterOperator) {
+    setSelectedOperator(op);
+    setStep(3);
+  }
+
+  function handleSubmit(val?: string) {
+    const finalValue = val ?? value;
+    if (!selectedColumn || !selectedOperator || !finalValue.trim()) return;
+    onAdd({
+      id: crypto.randomUUID(),
+      column: selectedColumn,
+      operator: selectedOperator,
+      value: finalValue,
+    });
+    onClose();
+  }
+
+  function goBack() {
+    if (step === 3) {
+      const config = selectedColumn ? FILTER_COLUMNS[selectedColumn] : null;
+      if (config && config.operators.length === 1) {
+        setSelectedColumn(null);
+        setSelectedOperator(null);
+        setStep(1);
+      } else {
+        setSelectedOperator(null);
+        setValue("");
+        setStep(2);
+      }
+    } else if (step === 2) {
+      setSelectedColumn(null);
+      setStep(1);
+    }
+  }
+
+  if (step === 1) {
+    return (
+      <div className="space-y-1">
+        <p className="text-xs font-medium text-muted-foreground px-2 py-1">
+          Filter by…
+        </p>
+        {(Object.entries(FILTER_COLUMNS) as [FilterColumn, (typeof FILTER_COLUMNS)[FilterColumn]][]).map(
+          ([key, config]) => (
+            <Button
+              key={key}
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start text-sm font-normal"
+              onClick={() => handleColumnSelect(key)}
+            >
+              {config.label}
+            </Button>
+          ),
+        )}
+      </div>
+    );
+  }
+
+  if (step === 2 && selectedColumn) {
+    const config = FILTER_COLUMNS[selectedColumn];
+    return (
+      <div className="space-y-1">
+        <button
+          onClick={goBack}
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground px-2 py-1"
+        >
+          <ChevronLeft className="h-3 w-3" />
+          {config.label}
+        </button>
+        {config.operators.map((op) => (
+          <Button
+            key={op}
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start text-sm font-normal"
+            onClick={() => handleOperatorSelect(op)}
+          >
+            {OPERATOR_LABELS[op]}
+          </Button>
+        ))}
+      </div>
+    );
+  }
+
+  if (step === 3 && selectedColumn && selectedOperator) {
+    const config = FILTER_COLUMNS[selectedColumn];
+    return (
+      <div className="space-y-2">
+        <button
+          onClick={goBack}
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground px-2 py-1"
+        >
+          <ChevronLeft className="h-3 w-3" />
+          {config.label} {OPERATOR_LABELS[selectedOperator]}
+        </button>
+        {config.options ? (
+          <div className="space-y-1">
+            {config.options.map((opt) => (
+              <Button
+                key={opt}
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start text-sm font-normal"
+                onClick={() => handleSubmit(opt)}
+              >
+                {opt}
+              </Button>
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-2 px-1">
+            <Input
+              autoFocus
+              placeholder="Type a value…"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSubmit();
+              }}
+              className="h-8 text-sm"
+            />
+            <Button
+              size="sm"
+              className="w-full"
+              disabled={!value.trim()}
+              onClick={() => handleSubmit()}
+            >
+              Apply
+            </Button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return null;
+}
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -44,6 +288,10 @@ export default function DashboardPage() {
   const [tickets, setTickets] = useState<Ticket[]>([]);
   const [ticketsError, setTicketsError] = useState<string | null>(null);
   const [ticketsLoading, setTicketsLoading] = useState(false);
+  const [filters, setFilters] = useState<Filter[]>([]);
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [sortColumn, setSortColumn] = useState<SortColumn>("created_at");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data }) => {
@@ -99,6 +347,102 @@ export default function DashboardPage() {
       const client = clients.find((c) => c.client_id === value) ?? null;
       setSelectedClient(client);
     }
+  }
+
+  function getTicketStatus(t: Ticket): string {
+    return t.status ?? (t.is_resolved ? "CLOSED" : "OPEN");
+  }
+
+  function toggleSort(column: SortColumn) {
+    if (sortColumn === column) {
+      setSortDirection((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortColumn(column);
+      setSortDirection(column === "created_at" ? "desc" : "asc");
+    }
+  }
+
+  function addFilter(filter: Filter) {
+    setFilters((prev) => [...prev, filter]);
+  }
+
+  function removeFilter(id: string) {
+    setFilters((prev) => prev.filter((f) => f.id !== id));
+  }
+
+  function clearAllFilters() {
+    setFilters([]);
+  }
+
+  const filteredTickets = useMemo(() => {
+    let result = tickets;
+
+    for (const filter of filters) {
+      result = result.filter((ticket) => {
+        let fieldValue: string;
+        if (filter.column === "is_resolved") {
+          fieldValue = ticket.is_resolved ? "Yes" : "No";
+        } else if (filter.column === "status") {
+          fieldValue = getTicketStatus(ticket);
+        } else {
+          fieldValue = (ticket[filter.column] as string | null) ?? "";
+        }
+
+        const filterVal = filter.value;
+
+        switch (filter.operator) {
+          case "contains":
+            return fieldValue.toLowerCase().includes(filterVal.toLowerCase());
+          case "does_not_contain":
+            return !fieldValue.toLowerCase().includes(filterVal.toLowerCase());
+          case "is":
+            return fieldValue.toLowerCase() === filterVal.toLowerCase();
+          case "is_not":
+            return fieldValue.toLowerCase() !== filterVal.toLowerCase();
+          default:
+            return true;
+        }
+      });
+    }
+
+    // Sort
+    const dir = sortDirection === "asc" ? 1 : -1;
+    result = [...result].sort((a, b) => {
+      switch (sortColumn) {
+        case "external_id": {
+          const aVal = a.external_id ?? "";
+          const bVal = b.external_id ?? "";
+          return dir * aVal.localeCompare(bVal);
+        }
+        case "short_desc":
+          return dir * a.short_desc.localeCompare(b.short_desc);
+        case "status": {
+          const aStatus = getTicketStatus(a);
+          const bStatus = getTicketStatus(b);
+          return dir * aStatus.localeCompare(bStatus);
+        }
+        case "created_at":
+          return (
+            dir *
+            (new Date(a.created_at).getTime() -
+              new Date(b.created_at).getTime())
+          );
+        default:
+          return 0;
+      }
+    });
+
+    return result;
+  }, [tickets, filters, sortColumn, sortDirection]);
+
+  function SortIcon({ column }: { column: SortColumn }) {
+    if (sortColumn !== column)
+      return <ArrowUpDown className="inline ml-1 h-3 w-3 opacity-40" />;
+    return sortDirection === "asc" ? (
+      <ArrowUp className="inline ml-1 h-3 w-3" />
+    ) : (
+      <ArrowDown className="inline ml-1 h-3 w-3" />
+    );
   }
 
   return (
@@ -168,6 +512,54 @@ export default function DashboardPage() {
             {ticketsError && (
               <p className="text-destructive text-sm">{ticketsError}</p>
             )}
+
+            {/* Power Search Filter Bar */}
+            {!ticketsLoading && tickets.length > 0 && (
+              <div className="flex items-center gap-2 flex-wrap">
+                <Popover open={filterOpen} onOpenChange={setFilterOpen}>
+                  <PopoverTrigger asChild>
+                    <Button variant="outline" size="sm">
+                      <ListFilter className="h-4 w-4 mr-1" />
+                      Add Filter
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-[220px] p-2" align="start">
+                    <FilterPopoverContent
+                      onAdd={addFilter}
+                      onClose={() => setFilterOpen(false)}
+                    />
+                  </PopoverContent>
+                </Popover>
+
+                {filters.map((f) => (
+                  <Badge key={f.id} variant="secondary" className="gap-1 pr-1">
+                    <span className="text-xs">
+                      {FILTER_COLUMNS[f.column].label}{" "}
+                      {OPERATOR_LABELS[f.operator]}{" "}
+                      <span className="font-semibold">{f.value}</span>
+                    </span>
+                    <button
+                      onClick={() => removeFilter(f.id)}
+                      className="ml-1 rounded-full hover:bg-muted p-0.5"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </Badge>
+                ))}
+
+                {filters.length > 1 && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={clearAllFilters}
+                    className="text-xs text-muted-foreground"
+                  >
+                    Clear all
+                  </Button>
+                )}
+              </div>
+            )}
+
             <Card className="overflow-hidden">
               <div className="overflow-x-auto">
                 {ticketsLoading ? (
@@ -182,38 +574,50 @@ export default function DashboardPage() {
                   <div className="px-4 py-8 text-center text-sm text-gray-500">
                     No tickets yet.
                   </div>
+                ) : filteredTickets.length === 0 ? (
+                  <div className="px-4 py-8 text-center text-sm text-gray-500">
+                    No tickets match your filters.
+                  </div>
                 ) : (
                   <table className="min-w-full divide-y divide-gray-200">
                     <thead className="bg-gray-50">
                       <tr>
                         <th
                           scope="col"
-                          className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
+                          className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider cursor-pointer select-none hover:text-gray-900"
+                          onClick={() => toggleSort("external_id")}
                         >
                           External ID
+                          <SortIcon column="external_id" />
                         </th>
                         <th
                           scope="col"
-                          className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
+                          className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider cursor-pointer select-none hover:text-gray-900"
+                          onClick={() => toggleSort("short_desc")}
                         >
                           Summary
+                          <SortIcon column="short_desc" />
                         </th>
                         <th
                           scope="col"
-                          className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
+                          className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider cursor-pointer select-none hover:text-gray-900"
+                          onClick={() => toggleSort("status")}
                         >
                           Status
+                          <SortIcon column="status" />
                         </th>
                         <th
                           scope="col"
-                          className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
+                          className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider cursor-pointer select-none hover:text-gray-900"
+                          onClick={() => toggleSort("created_at")}
                         >
                           Created
+                          <SortIcon column="created_at" />
                         </th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-gray-200 bg-white">
-                      {tickets.map((t) => (
+                      {filteredTickets.map((t) => (
                         <tr key={t.ticket_id} className="hover:bg-gray-50">
                           <td className="px-4 py-3 text-sm text-gray-600 whitespace-nowrap">
                             {t.external_id ?? "—"}
@@ -234,7 +638,7 @@ export default function DashboardPage() {
                                   : "text-amber-600 font-medium"
                               }
                             >
-                              {t.status ?? (t.is_resolved ? "CLOSED" : "OPEN")}
+                              {getTicketStatus(t)}
                             </span>
                           </td>
                           <td className="px-4 py-3 text-sm text-gray-600 whitespace-nowrap">

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/apps/web/components/ui/popover.tsx
+++ b/apps/web/components/ui/popover.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverAnchor = PopoverPrimitive.Anchor
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@supabase/ssr": "^0.5.0",
@@ -1930,6 +1931,84 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
@@ -2064,6 +2143,30 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.5.0",
@@ -33,8 +34,8 @@
     "eslint": "^8",
     "eslint-config-next": "14.2.3",
     "postcss": "^8",
-    "shadcn": "^3.8.5",
     "prettier": "^3.4.2",
+    "shadcn": "^3.8.5",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }

--- a/docs/scaling-notes.md
+++ b/docs/scaling-notes.md
@@ -1,0 +1,22 @@
+# Scaling Notes
+
+## Ticket Filtering: Client-Side vs Server-Side
+
+**Current (MVP):** All filtering, searching, and sorting on the ticket table is done client-side. The frontend fetches all tickets for a client in one API call and filters in the browser.
+
+**Why this works for now:** With small ticket counts (up to ~500 per client), client-side filtering is fast, simple, and avoids backend changes.
+
+**When to switch to server-side filtering:**
+
+When ticket counts per client grow into the thousands, move filtering to the backend:
+
+1. Accept filter query params on `GET /api/v1/tickets` (e.g. `?status=OPEN&short_desc__contains=apple`)
+2. Build dynamic SQLAlchemy `WHERE` clauses from the params in `apps/api/routes/tickets.py`
+3. Add pagination (`?page=1&limit=50`) to avoid loading everything at once
+4. Frontend sends filters as API params instead of filtering in memory
+5. The BFF proxy (`apps/web/app/api/v1/[...path]/route.ts`) already passes through query params, so no changes needed there
+
+**Signs it's time to switch:**
+- Dashboard load time feels sluggish
+- Ticket counts exceed ~500 per client
+- Users report slow search/filter interactions


### PR DESCRIPTION
## Summary
- Replace simple text search with a structured **power search filter builder** (column → operator → value) supporting multiple simultaneous AND filters
- Add **sortable column headers** (click to toggle asc/desc) on all four columns
- Install shadcn `Popover` and `Badge` components for the filter UI
- Add `docs/scaling-notes.md` documenting the trade-off of client-side vs server-side filtering

## How it works
- Click "Add Filter" → pick a column (External ID, Summary, Status, Priority, Resolved) → pick an operator (contains, does not contain, is, is not) → enter/select a value
- Enum columns (Status) show predefined choices; boolean columns (Resolved) show Yes/No
- Active filters appear as removable badge chips; "Clear all" shown with 2+ filters
- All filtering is client-side (see scaling-notes.md for server-side migration plan)

<img width="1063" height="524" alt="Screenshot 2026-03-06 at 8 57 44 PM" src="https://github.com/user-attachments/assets/e8de293c-4caa-4a60-93a6-ec489d0278b7" />


## Test plan
- [ ] Select a client with tickets on the dashboard
- [ ] Add a Status filter (is OPEN) — verify only open tickets show
- [ ] Add a Summary filter (contains "api") — verify AND logic narrows results
- [ ] Remove a filter badge — verify table updates
- [ ] Click "Clear all" — verify all filters removed
- [ ] Click column headers to sort — verify asc/desc toggling
- [ ] Verify "No tickets match your filters" message when filters produce zero results

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)