### PR TITLE
Add back button to taxonomies layout

### DIFF
--- a/apps/web/app/taxonomies/layout.tsx
+++ b/apps/web/app/taxonomies/layout.tsx
@@ -23,6 +23,12 @@ export default function TaxonomiesLayout({
     <div className="min-h-screen p-8">
       <div className="max-w-6xl mx-auto space-y-6">
         <div className="flex items-center gap-4 flex-wrap">
+          <Link
+            href="/dashboard"
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            ← Back
+          </Link>
           <h1 className="text-2xl font-bold">Taxonomies</h1>
           <nav className="flex items-center gap-1 flex-wrap">
             {nav.map(({ href, label }) => (


### PR DESCRIPTION
## Summary
- Add a "Back" link to the taxonomies layout that navigates to `/dashboard`
- Covers all taxonomy pages (overview, business-category, application, resolution, root-cause) via the shared layout

## Test plan
- [ ] Navigate to any taxonomy page and verify the back link appears
- [ ] Click it and verify it returns to the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)