### PR TITLE
fix: auth callback invite flow + users management page

### DIFF
--- a/apps/api/routes/tickets.py
+++ b/apps/api/routes/tickets.py
@@ -117,7 +117,7 @@ async def upload_tickets_csv(
     db: AsyncSession = Depends(get_db),
     client_id: uuid.UUID = Depends(get_effective_client_id),
 ):
-    """Parse CSV in memory, validate each row with TicketCreate, insert valid rows. Does not store the CSV."""
+    """Parse CSV in memory, validate each row with TicketCreate, insert valid rows."""
     if not file.filename or not file.filename.lower().endswith(".csv"):
         raise HTTPException(status_code=400, detail="File must be a CSV (filename ending in .csv)")
     content = await file.read()

--- a/apps/web/app/auth/callback/page.tsx
+++ b/apps/web/app/auth/callback/page.tsx
@@ -1,30 +1,50 @@
 "use client";
 
 import { createClient } from "@/lib/supabase";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { Suspense, useEffect, useMemo, useState } from "react";
 
 function CallbackHandler() {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const supabase = useMemo(() => createClient(), []);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const code = searchParams.get("code");
-    if (!code) {
-      setError("No auth code found in URL.");
-      return;
-    }
+    // createBrowserClient (detectSessionInUrl: true) automatically processes
+    // both PKCE (?code=) and implicit (#access_token=) flows and clears the
+    // URL before our effect runs. Manually re-parsing the hash or calling
+    // exchangeCodeForSession here would double-process the tokens and fail.
+    // Instead, subscribe to the SIGNED_IN event that auto-detection fires.
 
-    supabase.auth.exchangeCodeForSession(code).then(({ error }) => {
-      if (error) {
-        setError(error.message);
-      } else {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      if ((event === "SIGNED_IN" || event === "PASSWORD_RECOVERY") && session) {
         router.replace("/auth/set-password");
       }
     });
-  }, [searchParams, supabase, router]);
+
+    // If SIGNED_IN fired before our subscription was created, a session
+    // already exists — redirect immediately.
+    supabase.auth.getSession().then(({ data }) => {
+      if (data.session) {
+        router.replace("/auth/set-password");
+      }
+    });
+
+    // After 5s with no session, the link is invalid or expired.
+    const timer = setTimeout(async () => {
+      const { data } = await supabase.auth.getSession();
+      if (!data.session) {
+        setError("Invitation link is invalid or expired. Please request a new invite.");
+      }
+    }, 5000);
+
+    return () => {
+      subscription.unsubscribe();
+      clearTimeout(timer);
+    };
+  }, [supabase, router]);
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary

- **Root cause of invite redirect bug**: `createBrowserClient` has `detectSessionInUrl: true` by default, which auto-processes both PKCE and implicit flows and clears the URL before `useEffect` runs. Our manual hash-parsing always read an empty hash and showed 'No auth code found in URL.', leaving users stranded.
- **Fix**: Replaced manual token handling in `auth/callback` with `onAuthStateChange` (listening for `SIGNED_IN`), plus an immediate `getSession()` check for the race-condition case where the event fires before the subscription is created.
- **Also includes**: Full users management page and invite flow (issue #21) — `user_invitations` table, `GET /api/v1/users`, `POST /api/v1/users/invite`, `/users` page, `/auth/set-password` page, sidebar gating.
- **Ruff**: Fixed one E501 overlong docstring in `routes/tickets.py`.

## Test plan

- [ ] Admin sends invite from `/users` page → invited user receives Supabase email
- [ ] Clicking invite link → `/auth/callback` shows 'Verifying invitation...' then redirects to `/auth/set-password`
- [ ] Set-password form sets password → redirect to `/dashboard`
- [ ] Invited user can subsequently sign in via `/login` with their new password
- [ ] `GET /api/v1/users` returns 403 for Responder, 200 list for Admin/Developer
- [ ] Responder does not see 'Users' in sidebar; Admin and Developer do

Generated with [Claude Code](https://claude.com/claude-code)