### PR TITLE
debug: log invite redirect_to URL for Supabase mismatch fix

### DIFF
--- a/apps/api/routes/users.py
+++ b/apps/api/routes/users.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 import httpx
@@ -13,6 +14,7 @@ from routes.tickets import get_effective_client_id
 from schemas import UserInvite, UserRead
 from services import supabase_admin
 
+logger = logging.getLogger(__name__)
 router = APIRouter(tags=["users"])
 
 
@@ -89,6 +91,7 @@ async def invite_user(
         )
 
     redirect_to = f"{settings.site_url}/auth/callback"
+    logger.info("[invite] redirect_to=%s", redirect_to)
     try:
         auth_user = await supabase_admin.invite_user_by_email(body.email, redirect_to)
     except httpx.HTTPStatusError as exc:


### PR DESCRIPTION
## Summary
- Adds `logger.info("[invite] redirect_to=%s", redirect_to)` in the invite endpoint
- Lets us confirm in Railway logs exactly what URL is sent to Supabase
- Needed to diagnose why invite emails redirect to root domain instead of `/auth/callback`

## Test plan
- [ ] Deploy to Railway
- [ ] Send a test invite
- [ ] Check Railway logs for `[invite] redirect_to=https://skbasemvp.vercel.app/auth/callback`
- [ ] If log shows `localhost:3000`, add `SITE_URL` to Railway env vars and redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)