### PR TITLE
feat: add Enrich button to ticket detail page

### DIFF
--- a/apps/api/routes/tickets.py
+++ b/apps/api/routes/tickets.py
@@ -1,23 +1,27 @@
 import csv
 import io
+import logging
 import uuid
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
 from db import get_db
-from models import Ticket, TicketStatus, UserClient
+from models import Ticket, TicketStatus, TicketTaxonomy, UserClient
 from schemas import (
+    TaxonomyRead,
     TicketCreate,
     TicketRead,
     TicketStatusUpdate,
     TicketUploadResult,
     TicketUploadRowError,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["tickets"])
 
@@ -272,3 +276,44 @@ async def update_ticket_status(
     await db.commit()
     await db.refresh(ticket)
     return ticket
+
+
+@router.post("/tickets/{ticket_id}/enrich", response_model=list[TaxonomyRead])
+async def enrich_ticket(
+    ticket_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    client_id: uuid.UUID = Depends(get_effective_client_id),
+):
+    """Run AI taxonomy prediction for a ticket synchronously."""
+    result = await db.execute(
+        select(Ticket).where(Ticket.ticket_id == ticket_id, Ticket.client_id == client_id)
+    )
+    ticket = result.scalar_one_or_none()
+    if not ticket:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+
+    # Deactivate existing active taxonomy predictions
+    await db.execute(
+        update(TicketTaxonomy)
+        .where(
+            TicketTaxonomy.ticket_id == ticket_id,
+            TicketTaxonomy.client_id == client_id,
+            TicketTaxonomy.is_active.is_(True),
+        )
+        .values(is_active=False)
+    )
+
+    try:
+        from services.llm import extract_taxonomies
+
+        taxonomies = await extract_taxonomies(db, ticket)
+    except Exception:
+        logger.exception("Enrichment failed for ticket %s", ticket_id)
+        await db.rollback()
+        raise HTTPException(
+            status_code=502,
+            detail="Enrichment failed — the AI service may be temporarily unavailable.",
+        )
+
+    await db.commit()
+    return taxonomies

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { ClientProvider } from "@/contexts/ClientContext";
 import { AppShell } from "@/components/AppShell";
+import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -18,6 +19,7 @@ export default function RootLayout({
       <body className="bg-gray-50 text-gray-900 antialiased">
         <ClientProvider>
           <AppShell>{children}</AppShell>
+          <Toaster />
         </ClientProvider>
       </body>
     </html>

--- a/apps/web/app/tickets/[id]/page.tsx
+++ b/apps/web/app/tickets/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { toast } from "sonner";
 import type { ReactNode } from "react";
 import type {
   Ticket,
@@ -116,6 +117,7 @@ export default function TicketDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [taxonomyError, setTaxonomyError] = useState<string | null>(null);
   const [toggling, setToggling] = useState(false);
+  const [enriching, setEnriching] = useState(false);
 
   // Global taxonomy edit state
   const [isEditing, setIsEditing] = useState(false);
@@ -178,6 +180,32 @@ export default function TicketDetailPage() {
       setError(e instanceof Error ? e.message : "Failed to update status");
     } finally {
       setToggling(false);
+    }
+  }
+
+  async function handleEnrich() {
+    if (!ticket || !selectedClient) return;
+    const { data } = await supabase.auth.getSession();
+    const token = data.session?.access_token;
+    if (!token) return;
+    setEnriching(true);
+    try {
+      const result = await apiClient.post<Taxonomy[]>(
+        `/api/v1/tickets/${id}/enrich`,
+        token,
+        {},
+        { clientId: selectedClient.client_id },
+      );
+      setTaxonomies(result);
+      toast.success("Enrichment complete");
+    } catch (e: unknown) {
+      const msg =
+        e instanceof Error
+          ? e.message
+          : "Enrichment failed — please try again later.";
+      toast.error(msg);
+    } finally {
+      setEnriching(false);
     }
   }
 
@@ -453,14 +481,24 @@ export default function TicketDetailPage() {
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-bold">Taxonomies</h2>
               {!isEditing ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={startEditing}
-                  disabled={refLoading}
-                >
-                  Edit Taxonomies
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleEnrich}
+                    disabled={enriching}
+                  >
+                    {enriching ? "Enriching…" : "Enrich"}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={startEditing}
+                    disabled={refLoading || enriching}
+                  >
+                    Edit Taxonomies
+                  </Button>
+                </div>
               ) : (
                 <div className="flex items-center gap-2">
                   <Button

--- a/apps/web/components/ui/sonner.tsx
+++ b/apps/web/components/ui/sonner.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Toaster as Sonner } from "sonner";
+
+type ToasterProps = React.ComponentProps<typeof Sonner>;
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      theme="light"
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton:
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton:
+            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -22,9 +22,11 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
         "next": "14.2.35",
+        "next-themes": "^0.4.6",
         "react": "^18",
         "react-dom": "^18",
         "recharts": "^3.8.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -8377,6 +8379,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -10281,6 +10293,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,9 +24,11 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
     "next": "14.2.35",
+    "next-themes": "^0.4.6",
     "react": "^18",
     "react-dom": "^18",
     "recharts": "^3.8.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7"
   },


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/tickets/{id}/enrich` endpoint that synchronously runs AI taxonomy prediction via `TaxonomyPredictor`, deactivating old predictions first
- Adds "Enrich" button next to "Edit Taxonomies" on the ticket detail page with loading state
- Installs sonner (shadcn toast) for success/error notifications — gracefully handles AI service failures with HTTP 502 + toast error

## Test plan
- [ ] Open a ticket detail page, click "Enrich" — verify button shows "Enriching…", then taxonomies populate and success toast appears
- [ ] Click "Enrich" again — verify old predictions are replaced with fresh ones
- [ ] Simulate failure (e.g. invalid OpenAI key) — verify error toast appears, no crash
- [ ] Verify "Edit Taxonomies" still works independently
- [ ] Verify toast styling matches shadcn aesthetic

🤖 Generated with [Claude Code](https://claude.com/claude-code)