### PR TITLE
ui: bigger sidebar logo + reorder nav items

### DIFF
--- a/apps/web/components/AppSidebar.tsx
+++ b/apps/web/components/AppSidebar.tsx
@@ -34,14 +34,12 @@ import type { UserRole } from "@/lib/types";
 
 const NAV_ITEMS = [
   { label: "Overview", href: "/overview", icon: BarChart2, roles: null },
-  { label: "Analytics", href: "/analytics", icon: TrendingUp, roles: null },
   {
     label: "Dashboard",
     href: "/dashboard",
     icon: LayoutDashboard,
     roles: null,
   },
-  { label: "Taxonomies", href: "/taxonomies", icon: Tag, roles: null },
   {
     label: "Ingestion",
     href: "/ingestion",
@@ -54,6 +52,8 @@ const NAV_ITEMS = [
     icon: Users2,
     roles: ["Admin", "Developer"] as UserRole["role"][],
   },
+  { label: "Analytics", href: "/analytics", icon: TrendingUp, roles: null },
+  { label: "Taxonomies", href: "/taxonomies", icon: Tag, roles: null },
 ];
 
 export function AppSidebar({
@@ -97,10 +97,10 @@ export function AppSidebar({
   return (
     <Sidebar collapsible="icon" className="relative">
       <SidebarHeader className="px-4 py-3">
-        <span className="font-semibold text-sm group-data-[collapsible=icon]:hidden">
+        <span className="font-semibold text-lg group-data-[collapsible=icon]:hidden">
           SKBaseAI
         </span>
-        <span className="font-semibold text-sm hidden group-data-[collapsible=icon]:block">
+        <span className="font-semibold text-lg hidden group-data-[collapsible=icon]:block">
           SK
         </span>
       </SidebarHeader>


### PR DESCRIPTION
## Summary
- Increased "SKBaseAI" logo text size in sidebar from `text-sm` to `text-lg`
- Reordered nav items to: Overview, Dashboard, Ingestion, Users, Analytics, Taxonomies

## Test plan
- [ ] Verify sidebar shows larger "SKBaseAI" text
- [ ] Verify nav items appear in the new order
- [ ] Verify collapsed sidebar still shows "SK" correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)