### PR TITLE
fix: enriched taxonomies not persisted to DB

### DIFF
--- a/apps/api/routes/tickets.py
+++ b/apps/api/routes/tickets.py
@@ -335,6 +335,7 @@ async def enrich_ticket(
         from services.llm import extract_taxonomies
 
         taxonomies = await extract_taxonomies(db, ticket)
+        db.add_all(taxonomies)
     except Exception:
         logger.exception("Enrichment failed for ticket %s", ticket_id)
         await db.rollback()


### PR DESCRIPTION
## Summary

- The sync enrich endpoint (`POST /tickets/{id}/enrich`) was missing `db.add_all(taxonomies)`
- `extract_taxonomies()` returns new `TicketTaxonomy` ORM objects but they were never added to the DB session
- The taxonomies appeared in the API response (so the UI showed them immediately) but were never saved — navigating away and returning showed empty taxonomies

## Root cause

The async enrichment path (`services/enrichment.py:39`) already had `db.add_all(taxonomies)`, but the sync endpoint in `routes/tickets.py` was missing it.

## Fix

One-line fix: added `db.add_all(taxonomies)` before `db.commit()` in the enrich endpoint.

## Test plan
- [ ] Enrich a ticket via the Enrich button
- [ ] Navigate away to dashboard
- [ ] Click back into the ticket — taxonomies should still be populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)