### PR TITLE
fix: hide sidebar on auth pages and fix post-password login

### DIFF
--- a/apps/web/app/auth/set-password/page.tsx
+++ b/apps/web/app/auth/set-password/page.tsx
@@ -36,7 +36,8 @@ export default function SetPasswordPage() {
     if (updateError) {
       setError(updateError.message);
     } else {
-      router.replace("/dashboard");
+      await supabase.auth.signOut();
+      router.replace("/login");
     }
   }
 

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -39,7 +39,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     [sidebarWidth],
   );
 
-  if (pathname === "/login") {
+  if (pathname === "/login" || pathname.startsWith("/auth")) {
     return <>{children}</>;
   }
 


### PR DESCRIPTION
## Summary

- **Sidebar visible on auth pages:** AppShell only excluded `/login` from rendering the sidebar. Now it also excludes all `/auth/*` routes (set-password, callback, etc.)
- **Login fails after setting password:** After `updateUser()`, the app redirected to `/dashboard` with a stale invitation session. Now it signs out first, then redirects to `/login` so the user authenticates with their new credentials.

## Test plan
- [ ] Invite a user → they set password → clean login page (no sidebar visible) → can log in immediately
- [ ] Visit `/auth/set-password` directly → no sidebar shown
- [ ] Existing login flow still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)