### PR TITLE
feat: UX polish, enrichment visibility, and resolved_at fix

### DIFF
--- a/apps/api/routes/tickets.py
+++ b/apps/api/routes/tickets.py
@@ -2,6 +2,7 @@ import csv
 import io
 import logging
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import JSONResponse
@@ -301,6 +302,7 @@ async def update_ticket_status(
         raise HTTPException(status_code=404, detail="Ticket not found")
     ticket.status = body.status
     ticket.is_resolved = body.is_resolved
+    ticket.resolved_at = datetime.now(timezone.utc) if body.is_resolved else None
     await db.commit()
     await db.refresh(ticket)
     return ticket

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -14,12 +14,14 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   ArrowUp,
   ArrowDown,
   ArrowUpDown,
   ListFilter,
   ChevronLeft,
+  Inbox,
   X,
 } from "lucide-react";
 import type { Ticket } from "@/lib/types";
@@ -310,6 +312,21 @@ export default function DashboardPage() {
     return t.status ?? (t.is_resolved ? "CLOSED" : "OPEN");
   }
 
+  function enrichmentBadgeClass(status: string | null): string {
+    switch (status) {
+      case "COMPLETED":
+        return "border-green-200 bg-green-50 text-green-700";
+      case "PROCESSING":
+        return "border-blue-200 bg-blue-50 text-blue-700";
+      case "PENDING":
+        return "border-amber-200 bg-amber-50 text-amber-700";
+      case "FAILED":
+        return "border-red-200 bg-red-50 text-red-700";
+      default:
+        return "border-gray-200 bg-gray-50 text-gray-500";
+    }
+  }
+
   function toggleSort(column: SortColumn) {
     if (sortColumn === column) {
       setSortDirection((d) => (d === "asc" ? "desc" : "asc"));
@@ -477,20 +494,65 @@ export default function DashboardPage() {
             <Card className="overflow-hidden">
               <div className="overflow-x-auto">
                 {ticketsLoading ? (
-                  <div className="px-4 py-8 text-center text-sm text-gray-500">
-                    Loading tickets…
-                  </div>
+                  <table className="min-w-full divide-y divide-gray-200">
+                    <thead className="bg-gray-50">
+                      <tr>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">External ID</th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Summary</th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Status</th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Priority</th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Enrichment</th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Created</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200 bg-white">
+                      {Array.from({ length: 5 }).map((_, i) => (
+                        <tr key={i}>
+                          <td className="px-4 py-3"><Skeleton className="h-4 w-20" /></td>
+                          <td className="px-4 py-3"><Skeleton className="h-4 w-48" /></td>
+                          <td className="px-4 py-3"><Skeleton className="h-5 w-16 rounded-full" /></td>
+                          <td className="px-4 py-3"><Skeleton className="h-4 w-14" /></td>
+                          <td className="px-4 py-3"><Skeleton className="h-5 w-20 rounded-full" /></td>
+                          <td className="px-4 py-3"><Skeleton className="h-4 w-24" /></td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
                 ) : ticketsError ? (
                   <div className="px-4 py-8 text-center text-sm text-destructive">
                     Could not load tickets: {ticketsError}
                   </div>
                 ) : tickets.length === 0 ? (
-                  <div className="px-4 py-8 text-center text-sm text-gray-500">
-                    No tickets yet.
+                  <div className="px-4 py-16 text-center">
+                    <Inbox className="mx-auto h-10 w-10 text-muted-foreground/50" />
+                    <p className="mt-3 text-sm font-medium text-gray-900">No tickets yet</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Upload a CSV to get started with your first batch of tickets.
+                    </p>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="mt-4"
+                      onClick={() => router.push("/ingestion")}
+                    >
+                      Go to Ingestion
+                    </Button>
                   </div>
                 ) : filteredTickets.length === 0 ? (
-                  <div className="px-4 py-8 text-center text-sm text-gray-500">
-                    No tickets match your filters.
+                  <div className="px-4 py-16 text-center">
+                    <ListFilter className="mx-auto h-10 w-10 text-muted-foreground/50" />
+                    <p className="mt-3 text-sm font-medium text-gray-900">No tickets match your filters</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Try adjusting or clearing your filters.
+                    </p>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="mt-4"
+                      onClick={clearAllFilters}
+                    >
+                      Clear all filters
+                    </Button>
                   </div>
                 ) : (
                   <table className="min-w-full divide-y divide-gray-200">
@@ -529,6 +591,12 @@ export default function DashboardPage() {
                           onClick={() => toggleSort("created_at")}
                         >
                           Priority
+                        </th>
+                        <th
+                          scope="col"
+                          className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
+                        >
+                          Enrichment
                         </th>
                         <th
                           scope="col"
@@ -578,6 +646,14 @@ export default function DashboardPage() {
                           </td>
                           <td className="px-4 py-3 text-sm text-gray-600 whitespace-nowrap">
                             {t.priority ?? "—"}
+                          </td>
+                          <td className="px-4 py-3 text-sm whitespace-nowrap">
+                            <Badge
+                              variant="outline"
+                              className={enrichmentBadgeClass(t.enrichment_status)}
+                            >
+                              {t.enrichment_status ?? "N/A"}
+                            </Badge>
                           </td>
                           <td className="px-4 py-3 text-sm text-gray-600 whitespace-nowrap">
                             {new Date(t.created_at).toLocaleDateString()}

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -497,23 +497,47 @@ export default function DashboardPage() {
                   <table className="min-w-full divide-y divide-gray-200">
                     <thead className="bg-gray-50">
                       <tr>
-                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">External ID</th>
-                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Summary</th>
-                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Status</th>
-                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Priority</th>
-                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Enrichment</th>
-                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Created</th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                          External ID
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                          Summary
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                          Status
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                          Priority
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                          Enrichment
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                          Created
+                        </th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-gray-200 bg-white">
                       {Array.from({ length: 5 }).map((_, i) => (
                         <tr key={i}>
-                          <td className="px-4 py-3"><Skeleton className="h-4 w-20" /></td>
-                          <td className="px-4 py-3"><Skeleton className="h-4 w-48" /></td>
-                          <td className="px-4 py-3"><Skeleton className="h-5 w-16 rounded-full" /></td>
-                          <td className="px-4 py-3"><Skeleton className="h-4 w-14" /></td>
-                          <td className="px-4 py-3"><Skeleton className="h-5 w-20 rounded-full" /></td>
-                          <td className="px-4 py-3"><Skeleton className="h-4 w-24" /></td>
+                          <td className="px-4 py-3">
+                            <Skeleton className="h-4 w-20" />
+                          </td>
+                          <td className="px-4 py-3">
+                            <Skeleton className="h-4 w-48" />
+                          </td>
+                          <td className="px-4 py-3">
+                            <Skeleton className="h-5 w-16 rounded-full" />
+                          </td>
+                          <td className="px-4 py-3">
+                            <Skeleton className="h-4 w-14" />
+                          </td>
+                          <td className="px-4 py-3">
+                            <Skeleton className="h-5 w-20 rounded-full" />
+                          </td>
+                          <td className="px-4 py-3">
+                            <Skeleton className="h-4 w-24" />
+                          </td>
                         </tr>
                       ))}
                     </tbody>
@@ -525,9 +549,12 @@ export default function DashboardPage() {
                 ) : tickets.length === 0 ? (
                   <div className="px-4 py-16 text-center">
                     <Inbox className="mx-auto h-10 w-10 text-muted-foreground/50" />
-                    <p className="mt-3 text-sm font-medium text-gray-900">No tickets yet</p>
+                    <p className="mt-3 text-sm font-medium text-gray-900">
+                      No tickets yet
+                    </p>
                     <p className="mt-1 text-sm text-muted-foreground">
-                      Upload a CSV to get started with your first batch of tickets.
+                      Upload a CSV to get started with your first batch of
+                      tickets.
                     </p>
                     <Button
                       variant="outline"
@@ -541,7 +568,9 @@ export default function DashboardPage() {
                 ) : filteredTickets.length === 0 ? (
                   <div className="px-4 py-16 text-center">
                     <ListFilter className="mx-auto h-10 w-10 text-muted-foreground/50" />
-                    <p className="mt-3 text-sm font-medium text-gray-900">No tickets match your filters</p>
+                    <p className="mt-3 text-sm font-medium text-gray-900">
+                      No tickets match your filters
+                    </p>
                     <p className="mt-1 text-sm text-muted-foreground">
                       Try adjusting or clearing your filters.
                     </p>
@@ -650,7 +679,9 @@ export default function DashboardPage() {
                           <td className="px-4 py-3 text-sm whitespace-nowrap">
                             <Badge
                               variant="outline"
-                              className={enrichmentBadgeClass(t.enrichment_status)}
+                              className={enrichmentBadgeClass(
+                                t.enrichment_status,
+                              )}
                             >
                               {t.enrichment_status ?? "N/A"}
                             </Badge>

--- a/apps/web/app/ingestion/page.tsx
+++ b/apps/web/app/ingestion/page.tsx
@@ -6,9 +6,19 @@ import { createClient } from "@/lib/supabase";
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Download, FileSpreadsheet } from "lucide-react";
 
 import type { UserRole } from "@/lib/types";
+
+type UploadEntry = {
+  id: string;
+  filename: string;
+  timestamp: Date;
+  created: number;
+  errorsCount: number;
+};
 
 const ALLOWED_ROLES: UserRole["role"][] = ["Admin", "Developer"];
 
@@ -26,6 +36,7 @@ export default function IngestionPage() {
     null,
   );
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadHistory, setUploadHistory] = useState<UploadEntry[]>([]);
 
   useEffect(() => {
     supabase.auth.getSession().then(async ({ data }) => {
@@ -71,6 +82,16 @@ export default function IngestionPage() {
         { clientId: selectedClient.client_id },
       );
       setUploadResult(result);
+      setUploadHistory((prev) => [
+        {
+          id: crypto.randomUUID(),
+          filename: uploadFile.name,
+          timestamp: new Date(),
+          created: result.created,
+          errorsCount: result.errors.length,
+        },
+        ...prev,
+      ]);
       setUploadFile(null);
     } catch (e: unknown) {
       setUploadError(e instanceof Error ? e.message : "Upload failed");
@@ -97,9 +118,68 @@ export default function IngestionPage() {
           </p>
         </div>
 
+        {/* CSV Format Guide — always visible */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-bold">CSV Format Guide</h2>
+              <Button variant="outline" size="sm" asChild>
+                <a href="/sample-tickets.csv" download>
+                  <Download className="h-4 w-4 mr-1" />
+                  Download Sample CSV
+                </a>
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <p className="text-sm font-medium mb-2">Required columns</p>
+              <div className="flex flex-wrap gap-2">
+                {["short_desc", "status", "source_system", "external_id"].map(
+                  (col) => (
+                    <Badge
+                      key={col}
+                      variant="secondary"
+                      className="font-mono text-xs"
+                    >
+                      {col}
+                    </Badge>
+                  ),
+                )}
+              </div>
+            </div>
+            <div>
+              <p className="text-sm font-medium mb-2">Optional columns</p>
+              <div className="flex flex-wrap gap-2">
+                {["full_desc", "resolution", "root_cause", "priority"].map(
+                  (col) => (
+                    <Badge
+                      key={col}
+                      variant="outline"
+                      className="font-mono text-xs"
+                    >
+                      {col}
+                    </Badge>
+                  ),
+                )}
+              </div>
+            </div>
+            <div className="text-sm text-muted-foreground space-y-1">
+              <p>
+                <span className="font-medium">Status values:</span> OPEN or
+                CLOSED
+              </p>
+              <p>
+                <span className="font-medium">File limits:</span> 5 MB max,
+                5,000 rows max
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
         {!selectedClient && (
           <p className="text-sm text-muted-foreground">
-            Select a client on the dashboard first.
+            Select a client from the dropdown above to upload tickets.
           </p>
         )}
 
@@ -218,16 +298,53 @@ export default function IngestionPage() {
               </CardContent>
             </Card>
 
-            {/* History placeholder */}
+            {/* Recent Uploads (session) */}
             <Card>
               <CardHeader>
-                <h2 className="text-lg font-bold">Ingestion History</h2>
+                <h2 className="text-lg font-bold">Recent Uploads</h2>
+                <p className="text-sm text-muted-foreground">
+                  Upload history for this session
+                </p>
               </CardHeader>
               <CardContent>
-                <p className="text-sm text-muted-foreground">
-                  Run-level ingestion history will appear here once job tracking
-                  is enabled.
-                </p>
+                {uploadHistory.length === 0 ? (
+                  <div className="py-8 text-center">
+                    <FileSpreadsheet className="mx-auto h-10 w-10 text-muted-foreground/50" />
+                    <p className="mt-3 text-sm text-muted-foreground">
+                      No uploads yet this session. Upload a CSV above to get
+                      started.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="divide-y">
+                    {uploadHistory.map((entry) => (
+                      <div
+                        key={entry.id}
+                        className="py-3 flex items-center justify-between"
+                      >
+                        <div>
+                          <p className="text-sm font-medium">
+                            {entry.filename}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {entry.timestamp.toLocaleTimeString()}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Badge variant="secondary" className="text-xs">
+                            {entry.created} created
+                          </Badge>
+                          {entry.errorsCount > 0 && (
+                            <Badge variant="destructive" className="text-xs">
+                              {entry.errorsCount} error
+                              {entry.errorsCount !== 1 ? "s" : ""}
+                            </Badge>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </CardContent>
             </Card>
           </>

--- a/apps/web/app/tickets/[id]/page.tsx
+++ b/apps/web/app/tickets/[id]/page.tsx
@@ -376,6 +376,22 @@ export default function TicketDetailPage() {
                   TEST
                 </Badge>
               )}
+              {ticket.enrichment_status && (
+                <Badge
+                  variant="outline"
+                  className={`text-xs ${
+                    ticket.enrichment_status === "COMPLETED"
+                      ? "border-green-200 bg-green-50 text-green-700"
+                      : ticket.enrichment_status === "PROCESSING"
+                        ? "border-blue-200 bg-blue-50 text-blue-700"
+                        : ticket.enrichment_status === "PENDING"
+                          ? "border-amber-200 bg-amber-50 text-amber-700"
+                          : "border-red-200 bg-red-50 text-red-700"
+                  }`}
+                >
+                  {ticket.enrichment_status}
+                </Badge>
+              )}
             </div>
           </CardHeader>
           <CardContent className="space-y-6">

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -19,6 +19,7 @@ export type Ticket = {
   created_at: string;
   updated_at: string;
   resolved_at: string | null;
+  enrichment_status: string | null;
 };
 
 export type Taxonomy = {


### PR DESCRIPTION
## Summary
- **Fix `resolved_at` on status toggle** — sets timestamp when resolving, clears when reopening, fixing MTTR analytics
- **Dashboard UX overhaul** — skeleton table loader, empty states with icons/CTAs, new Enrichment column with color-coded status badges
- **Enrichment visibility** — `enrichment_status` added to frontend Ticket type and displayed on both dashboard and ticket detail pages
- **Ingestion page completion** — CSV Format Guide with required/optional columns and sample download, session-based upload history replacing placeholder

## Test plan
- [ ] Toggle a ticket closed → verify `resolved_at` is set; reopen → verify it clears
- [ ] Load dashboard with tickets → see Enrichment column with colored badges
- [ ] Load dashboard without tickets → see empty state with "Go to Ingestion" CTA
- [ ] Apply filters with no matches → see "Clear all filters" CTA
- [ ] Refresh dashboard → see skeleton table while loading
- [ ] View ticket detail → see enrichment status badge next to title
- [ ] Visit ingestion page → see CSV Format Guide and "Download Sample CSV" button
- [ ] Upload a CSV → see entry in Recent Uploads section

🤖 Generated with [Claude Code](https://claude.com/claude-code)